### PR TITLE
Añada ejercicio 7.8.1

### DIFF
--- a/sample_css/index.html
+++ b/sample_css/index.html
@@ -28,13 +28,13 @@
     }
 
     /* BIO STYLES */
-    .bio-wrapper {
+    /* .bio-wrapper {
       font-size: 24px;
-    }
+    } */
 
     .bio-box {
       border: 1px solid black;
-      font-size: 1rem;
+      font-size: 1em;
       width: 50%;
     }
 
@@ -55,12 +55,20 @@
       background-color: #c7dbfc;
       height: 50vh;
     }
+
+    .body-font-size {
+      font-size: 62.5%;
+    }
+
+    .h1-font-size {
+      font-size: 2em;
+    } 
   </style>
 </head>
 
-<body>
+<body class="body-font-size">
   <div class="full-hero hero-home">
-    <h1>I'm an h1</h1>
+    <h1 class="h1-font-size"> I'm an h1 </h1>
     <ul>
       <li>
         <a href="https://example.com/" class="social-link">Link</a>


### PR DESCRIPTION
1. Se probó el truco del 62,5 %, al configurar el cuerpo de la página de prueba para que tuviera un tamaño de fuente del 62,5%. Se puede observar que la mayor parte del texto se hizo más pequeño, con la excepción de .bioboxes que se están redimensionando con el del tamaño de fuente html gracias a la unidad rem.
Antes:
<img width="756" alt="Captura de pantalla 2023-04-23 a la(s) 8 20 04 p  m" src="https://user-images.githubusercontent.com/126674342/233875690-ddcb0ff7-270a-4883-a1b0-7628f1580b3c.png">
Despues:
<img width="757" alt="Captura de pantalla 2023-04-23 a la(s) 8 20 30 p  m" src="https://user-images.githubusercontent.com/126674342/233875719-a7bb201b-2007-4007-9efc-9b8105815487.png">

2. Se cambió el tamaño de fuente del h1 a 20px, y luego, después de ver cómo se ve, se cambió a 2em. Ningún cambio entre ambas.
Antes:
<img width="457" alt="Captura de pantalla 2023-04-23 a la(s) 8 22 31 p  m" src="https://user-images.githubusercontent.com/126674342/233876164-3ee61b71-024e-44d1-9e5f-74ef019d0f60.png">
Despues (20px/2em):
<img width="586" alt="Captura de pantalla 2023-04-23 a la(s) 8 25 02 p  m" src="https://user-images.githubusercontent.com/126674342/233876184-d948049a-4367-4d7a-9be4-0a3957439bce.png">

3. Se eliminó el tamaño de fuente que estaba en la clase .bio-wrapper y luego se configuró el tamaño de la fuente del .bio-box a 1em.
Antes:
<img width="754" alt="Captura de pantalla 2023-04-23 a la(s) 8 26 37 p  m" src="https://user-images.githubusercontent.com/126674342/233876288-3605b6d3-ec33-4388-97f5-cad5b6de98f6.png">
Despues:
<img width="756" alt="Captura de pantalla 2023-04-23 a la(s) 8 26 52 p  m" src="https://user-images.githubusercontent.com/126674342/233876297-a9764ebc-a7a0-4d50-b4a9-643a0a598333.png">

**NO APROBAR NI MEZCLAR.**