### PR TITLE
Exercise.8.2.2.

### DIFF
--- a/sample_css/index.html
+++ b/sample_css/index.html
@@ -62,10 +62,10 @@
       height: 50vh;
     }
 
-    /* remove later */
-    /* .test-box {
+    .test-box {
       background: #9db6dd;
       margin: 50px;
+      width: 200px;
     }
 
     .test-box-nosizing {
@@ -75,8 +75,9 @@
 
     .test-box-sizing {
       box-sizing: border-box;
-    } */
-    /* remove later */
+      width: auto;
+      margin-top: 100px;
+    }
   </style>
 </head>
 
@@ -98,8 +99,7 @@
 
   <h2>I'm an h2</h2>
 
-  <!-- remove later  -->
-  <!-- <div class="test-box">
+  <div class="test-box">
     200px wide
   </div>
   <div class="test-box test-box-nosizing">
@@ -107,8 +107,7 @@
   </div>
   <div class="test-box test-box-nosizing test-box-sizing">
     200px wide + border + padding + box-sizing: border-box = 200px
-  </div> -->
-  <!-- remove later  -->
+  </div>
 
   <div class="test-box">
     <div class="bio-wrapper">


### PR DESCRIPTION
1. Se cambió el tamaño de los dos primeros elementos de bloque agregando un estilo para establecer el ancho de .test-box a 200px, y se estableció el ancho de .test-box-sizing a auto para desarmar el valor de ancho previamente establecido.
Antes:
<img width="873" alt="Captura de pantalla 2023-04-25 a la(s) 8 37 24 p  m" src="https://user-images.githubusercontent.com/126674342/234437992-304f5db6-c77b-4d30-87df-70ec7519fd80.png">
Despues (width: 200px):
<img width="864" alt="Captura de pantalla 2023-04-25 a la(s) 8 47 25 p  m" src="https://user-images.githubusercontent.com/126674342/234438150-ea5c4e8b-6d32-41cb-ac3d-9acfc1446c7c.png">
Despues (width: auto):
<img width="870" alt="Captura de pantalla 2023-04-25 a la(s) 8 37 48 p  m" src="https://user-images.githubusercontent.com/126674342/234437521-f5e9c6a4-61d6-4f86-90b9-cf65f0885187.png">

2. Se agregó un estilo que establece un margen superior de 100 px en la clase .test-box-sizing.
Antes:
<img width="870" alt="Captura de pantalla 2023-04-25 a la(s) 8 37 48 p  m" src="https://user-images.githubusercontent.com/126674342/234437609-4893e001-e2cc-4349-b5d6-b1ff80b5c9aa.png">
Despues:
<img width="877" alt="Captura de pantalla 2023-04-25 a la(s) 8 50 37 p  m" src="https://user-images.githubusercontent.com/126674342/234438353-06bce4f7-52b3-430d-9cb7-0143e71d1ca1.png">

**NO MEZCLAR.**