### PR TITLE
Hacer ejercicio 8.6.3

### DIFF
--- a/sample_css/index.html
+++ b/sample_css/index.html
@@ -33,7 +33,7 @@
     /* BIO STYLES */
     .bio-wrapper {
       font-size: 24px;
-      margin: auto;
+      margin: 0 auto 100px;
       max-width: 960px;
       overflow: hidden;
     }
@@ -55,6 +55,10 @@
       margin: 40px 1% 0;
       padding: 0 2% 2%;
       width: 23%;
+    }
+
+    .bio-box .social-link{
+      margin: auto;
     }
 
     .bio-box img {


### PR DESCRIPTION
- Se añadió un espacio aleatorio (en este caso 100px) debajo de .bio-weapper manteniendo en auto los márgenes de la izquierda y derecha y el superior en 0.

**Antes:**
<img width="1426" alt="Captura de pantalla 2023-04-27 a la(s) 3 13 50 p m" src="https://user-images.githubusercontent.com/126674411/234988028-61ea914d-62fe-4c69-ad5d-9db0bc9ddad0.png">

**Despues:**
<img width="1406" alt="Captura de pantalla 2023-04-27 a la(s) 3 14 23 p m" src="https://user-images.githubusercontent.com/126674411/234988420-86a7fd64-645f-43a1-8f8b-51f9db939f4b.png">

- Se intento centrar los .social-link que estaban dentro de .bio-box con margin auto sin embargo esto no se logra ya que .social-link tiene la propiedad display: inline-block y margin: auto funciona para display:block. Por lo tanto como se ve en la figura los links (que dicen here) no se centran.

<img width="1314" alt="Captura de pantalla 2023-04-27 a la(s) 3 48 31 p m" src="https://user-images.githubusercontent.com/126674411/234989284-1acebe79-9864-487b-b637-4a0ce20fa671.png">

Aquí en esta pagina encontré lo que dice arriba.

<img width="1001" alt="Captura de pantalla 2023-04-27 a la(s) 3 57 14 p m" src="https://user-images.githubusercontent.com/126674411/234989435-67387039-8046-44cc-8c3b-48493f403eae.png">

https://weekendprojects.dev/posts/fixing-css-margin-auto-not-working-issues/


**NO MEZCLAR**