### PR TITLE
Hacer Exercise8.7.1

### DIFF
--- a/sample_css/index.html
+++ b/sample_css/index.html
@@ -73,8 +73,9 @@
       padding: 20px;
     }
 
-    .bio-copy a {
+    .bio-copy-a {
       color: green;
+      padding: 20px;
     }
 
     /* HERO STYLES */
@@ -90,7 +91,7 @@
     <h1>I'm an h1</h1>
     <ul>
       <li>
-        <a href="https://example.com/" class="social-link">Link</a>
+        <a href="https://example.com/" class="social-link bio>Link</a>
       </li>
       <li>
         <a href="https://example.com/" class="social-link">Link</a>
@@ -108,7 +109,7 @@
       <div class="bio-box">
         <img src="https://placekitten.com/g/400/400">
         <h3>Michael Hartl</h3>
-        <a href="https://twitter.com/mhartl" class="social-link">here</a>
+        <a href="https://twitter.com/mhartl" class="social-link bio-copy-a">here</a>
         <div class="bio-copy">
           <p>
             Known for his dazzling charm, rapier wit, and unrivaled
@@ -132,7 +133,7 @@
       <div class="bio-box">
         <img src="https://placekitten.com/g/400/400">
         <h3>Lee Donahoe</h3>
-        <a href="https://twitter.com/leedonahoe" class="social-link">here</a>
+        <a href="https://twitter.com/leedonahoe" class="social-link bio-copy-a">here</a>
         <div class="bio-copy">
           <p>
             When he's not literally swimming with sharks or hunting
@@ -148,7 +149,7 @@
       <div class="bio-box">
         <img src="https://placekitten.com/g/400/400">
         <h3>Nick Merwin</h3>
-        <a href="https://twitter.com/nickmerwin" class="social-link">here</a>
+        <a href="https://twitter.com/nickmerwin" class="social-link bio-copy-a">here</a>
         <div class="bio-copy">
           <p>
             You may have seen him shredding guitar live with Capital

--- a/sample_css/index.html
+++ b/sample_css/index.html
@@ -70,6 +70,7 @@
 
     .bio-copy {
       font-size: 1em;
+      padding: 20px;
     }
 
     .bio-copy a {


### PR DESCRIPTION
Se agregó un padding de 20 px a los enlaces que están dentro de las secciones .bio-copy.
Antes:
<img width="1468" alt="Captura de pantalla 2023-04-27 a la(s) 8 51 40 p  m" src="https://user-images.githubusercontent.com/126674342/235029252-eb221795-2dc3-48a4-b2f7-90cb939f682a.png">
Despues:
<img width="1470" alt="Captura de pantalla 2023-04-27 a la(s) 8 52 03 p  m" src="https://user-images.githubusercontent.com/126674342/235029262-423a3e7f-d46a-472a-b74d-422ad1d0d6ce.png">

NOTA: A pesar de que ya existia la clase .bio-box a, no estaba aplicada a los links. Dicha clase ya contaba con el color verde.

NO MEZCLAR.