### PR TITLE
solucion de errores de jekyll y documentacion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .ruby-gemset
 .bundle
+.jekyll-cache
+_site/

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@
 # https://stackoverflow.com/questions/74339443/cant-install-jekyll-fatal-error-openssl-ssl-h-file-not-found
 source 'https://rubygems.org'
 gem 'jekyll', '4.2.1'
+gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,12 +56,14 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   arm64-darwin-22
 
 DEPENDENCIES
   jekyll (= 4.2.1)
+  webrick
 
 BUNDLED WITH
    2.2.17

--- a/README.md
+++ b/README.md
@@ -363,7 +363,31 @@ rvm gemset list
 rvm --create --ruby-version use <version_ruby>@<gemset_name>
 ```
 
+### Instalacion 
 
+- Instalar openssl usando este comando (solo para Mac):   
+```shell
+brew install openssl@3
+```
+
+- Instalar las dependencias con:
+```shell
+ bundle _2.2.17_ install
+```
+
+### Verificar que funciona
+
+- Moverse a sample_website:  
+```shell
+cd sample_website
+```
+- Correr jekyll: 
+```shell
+ bundle _2.2.17_ exec jekyll serve  
+```
+- copiar en el navegador: http://127.0.0.1:4000/
+
+- Para salir de jekyll server presiona Ctrl + c
 # TODO.
 - configurar consola
 - configurar rvm autocomplete


### PR DESCRIPTION
- Añadir `webrick` al Gemset
- actualizacion del Gemset.lock por el cambio anterior
- ignorar algunos archivos que crea jekyll y que no son necesarios
- Documentacion de Jekyll añadida