### PR TITLE
Añada ejercicio 9.6.3

### DIFF
--- a/sample_jekyll/_includes/header.html
+++ b/sample_jekyll/_includes/header.html
@@ -9,3 +9,4 @@
     </nav>
     <a href="/" class="header-logo">Logo</a>
 </header>
+{{ include.content }}

--- a/sample_jekyll/_layouts/default.html
+++ b/sample_jekyll/_layouts/default.html
@@ -2,7 +2,7 @@
 <html>
     {% include head.html %}
     <body>
-        {% include header.html %}
+        {% include header.html content="This is my sample note." %}
         <div class="full-hero hero-home">
             <h1>I’m an h1</h1>
             <ul class="social-list">


### PR DESCRIPTION
Se agregó el código adicional {{ include.content }} en header.html include y luego, en el layout, se cambió la etiqueta include a {% include header.html content="This is my sample note." %}.
Antes:
<img width="1451" alt="Captura de pantalla 2023-05-10 a la(s) 9 34 26 p  m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674342/19642c79-685a-4713-9056-2503e7d7e769">
Despues:
<img width="1452" alt="Captura de pantalla 2023-05-10 a la(s) 9 35 31 p  m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674342/494c4f65-7cc2-47a6-83ec-3b4a55bebb62">

**NO ES NECESARIO MEZCLAR**