### PR TITLE
Hacer ejercicio 11.2.1

### DIFF
--- a/sample_jekyll/css/main.css
+++ b/sample_jekyll/css/main.css
@@ -321,17 +321,29 @@ h2 ~ p {
   text-align: center;
 }
 .home-callout {
+  align-items: flex-end;
   background-color: #000;
   color: #fff;
   padding: 7vh 0;
+  display: flex;
+  padding: 7vh 0;
+}
+.home-callout h3 {
+  color: inherit;
+  margin-top: 1em;
 }
 .callout-title {
+  flex-basis: 0;
+  flex-grow: 1;
   font-size: 5.75vw;
   text-align: right;
   text-transform: uppercase;
 }
 .callout-copy {
+  flex-basis: 45em;
+  flex-shrink: 0;
   font-size: 0.8rem;
+  padding: 03 vw;
 }
 
 /* BIO STYLES */


### PR DESCRIPTION
## css(ejercicio 11.2.1)

Se realizo el ejercicio 11.2.1 de CSS donde se pedia se cambiara en .home-callout la propiedad align-items que se encontraba en center.

### Changelog

- Se cambio de center a flex-start y luego a flex-end.

### Checklist

Así se encontraba originalmente con la propiedad center
<img width="855" alt="Captura de pantalla 2023-06-25 a la(s) 4 34 15 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/0502e23b-0737-490b-9895-8af812f3ff26">

Así quedo con la propiedad flex-start
<img width="814" alt="Captura de pantalla 2023-06-25 a la(s) 4 33 53 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/078c3d50-ea91-4533-9e4e-8abe50e26bf0">

Y ya por ultimo quedo con flex-end de esta manera:
<img width="817" alt="Captura de pantalla 2023-06-25 a la(s) 4 36 25 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/4b9b4bff-70a0-4d10-b5ff-032fe912fd8a">

### Also see

- En la siguiente pagina podemos ver como se comportan las propiedades de Flexbox

https://css-tricks.com/snippets/css/a-guide-to-flexbox/

Aquí se muestra un pantallazo de dicha pagina:
<img width="396" alt="Captura de pantalla 2023-06-25 a la(s) 5 10 01 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/1ab4ef90-d5e3-458e-86d9-8a953176ba2f">

