### PR TITLE
Hacer ejercicio 11.5.1

### DIFF
--- a/sample_jekyll/css/main.css
+++ b/sample_jekyll/css/main.css
@@ -203,6 +203,7 @@ h2 ~ p {
 }
 .gallery-thumbs img:hover {
   opacity: 1;
+  width: 50%;
 }
 .gallery-thumbs .current img {
   box-shadow: 0 0 0 5px #ed6e2f;
@@ -219,6 +220,9 @@ h2 ~ p {
 }
 .gallery-info h3 {
   margin-bottom: 1em;
+}
+.gallery-thumbs .current {
+  cursor: default;
 }
 
 /* HEADER STYLES */


### PR DESCRIPTION
# css(ejercicio 11.5.1)

Se realizó el ejercicio 11.5.1 del libro de css

## Changelog

- Se cambio el tiempo de transición es decir la propiedad transition de 0.5s a 2s
- Se agregó a la declaración .gallery-thumbs img:hover un width: 50%
- Se agregó una declaración llamada .gallery-thumbs .current y se le añadió el estilo cursor: default 

## PREVIEW
-  En la primera parte del ejercicio a partir de imágenes no se logra observar por ser como una animación.

- En la segunda parte se observa como disminuye el ancho de la segunda imagen. Antes:
<img width="601" alt="Captura de pantalla 2023-07-03 a la(s) 8 53 37 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/b2f4a504-8842-43dd-9602-dba4b6b1a44c">
Después:
<img width="757" alt="Captura de pantalla 2023-07-03 a la(s) 8 56 14 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/2ab1ff00-52ad-40ba-aa19-0c43fc490b6e">

- La tercera parte no se logra observar el curso con la captura de pantalla.

