### PR TITLE
Añada ejercicio 12.1.2

### DIFF
--- a/sample_jekyll/css/main.css
+++ b/sample_jekyll/css/main.css
@@ -173,6 +173,7 @@ h2 ~ p {
 }
 .col-two .col-aside {
   flex: 0 0 20em;
+  flex-direction: column;
   order: 1;
 }
 .col-two .col-content {


### PR DESCRIPTION
# CSS (ejercicio 12.1.2)

Se realizo el ejercicio 11.2.1 de CSS, donde se pedia:
-Explicar que ocurrió en el footer.
-Detallar como agregar comentarios utilizando servicios de terceros.
-Establecer la propiedad order: para .col-two .col-aside a 0. Luego cambiar flex-direction a column; y finalmente establecerlo order a 1.

## Changelog

- Se cambió order: para .col-two .col-aside a 0. 
- Se agregó flex-direction: column.
- Se cambió order a 1 como inicialmente estaba.

## Checklist

1. Sucedió algo interesante en el footer de la nueva página de índice del blog que se muestra en la Figura 12.5. ¿Qué pasó y por qué? Sugerencia: recuerde el principio DRY.

Los nav-links fueron actualizados automaticamente en el footer al incluir "blog", ya que está incluido en el include.

2. Muchos (probablemente la mayoría) de los blogs incluyen la posibilidad de que los lectores dejen comentarios, pero debido a que Jekyll es un generador de sitios estáticos sin base de datos, no es posible admitir comentarios de forma nativa. Afortunadamente, hay maneras de agregar en comentarios utilizando servicios de terceros. Use su sofisticación técnica y Google-fu para ver si puede encontrar un sistema de comentarios que pueda colocar en un sitio estático:

- Primero, cree una cuenta en Just Comments iniciando sesión a través de Github o Facebook. Verá su clave API que el sistema ha generado automáticamente.
- Ahora necesitamos modificar la plantilla del blog e integrar el widget en nuestro blog. Para ello, personalice el tema existente de su blog. Por ejemplo, para personalizar el tema predeterminado llamado mínimos, cree el archivo _includes/head.html en su editor favorito. Coloque el contenido especificado en el link al final.
- Al agregar la etiqueta del script, incrustamos el widget proporcionado por Just Comments que impulsará nuestros comentarios.
- Coloque el elemento contenedor para los comentarios donde desee que esté. Para esto, necesitamos personalizar la plantilla de publicación creando el archivo ./_layouts/post.html con el siguiente contenido. Reemplace YOUR_API_KEY con la clave API real para su cuenta de Just Comments.

3. Intente establecer la propiedad order: para .col-two .col-aside en 0. Ahora cambie la dirección flexible a columna; el aparte debe estar en la parte superior de la página. Ahora intente volver a establecerlo en 1 para empujarlo hasta el fondo.

- .col-two .col-aside inicialmente:
<img width="1073" alt="Captura de pantalla 2023-07-10 a la(s) 9 47 50 p  m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674342/687f81d4-a7b1-4912-b173-2583db6856df">

- .col-two .col-aside con order: 0
<img width="1089" alt="Captura de pantalla 2023-07-10 a la(s) 9 48 11 p  m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674342/da8d6141-a0e2-4ec5-978e-5c7f6879049a">

- .col-two .col-aside con flex-direction: column y order:1
<img width="1092" alt="Captura de pantalla 2023-07-10 a la(s) 9 50 50 p  m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674342/8167a6b1-6194-48f1-bb07-75933c5fd988">

## Also see

- Agregar comentarios a un blog de Jekyll (https://60devs.com/adding-comments-to-your-jekyll-blog.html#:~:text=Adding%20comments%20to%20Jekyll%20blog&text=First%2C%20create%20an%20account%20at,the%20system%20has%20automatically%20generated.&text=By%20adding%20the%20script%20tag,which%20will%20power%20our%20comments.)

### NO MEZCLAR.