### PR TITLE
Añada ejercicio 13.1.1

### DIFF
--- a/sample_jekyll/_layouts/post.html
+++ b/sample_jekyll/_layouts/post.html
@@ -5,7 +5,7 @@ layout: default
 <div class="post">
     <div
         class="half-hero"
-        style="background-image:url({{ page.postHero }})"
+        style="background-image: url('{{ page.postHero }}')"
     ></div>
     <article class="page">
         <header class="post-header">

--- a/sample_jekyll/css/main.css
+++ b/sample_jekyll/css/main.css
@@ -465,6 +465,11 @@ h2 ~ p {
   background-color: #000;
   color: #fff;
 }
+@media(max-width:600px){
+  .half-hero{
+    display: none; 
+  }
+}
 .half-hero {
   background-position: center center;
   background-size: cover;


### PR DESCRIPTION
# CSS (ejercicio 13.1.1)

Se realizo el ejercicio 13.1.1 de CSS, donde se pedia:
-Agregar un segundo punto de interrupción con un nuevo media query para apuntar a ventanas que son más estrechas que 600 px, y utilizarlo para ocultar el .half-hero

## Changelog

- Se agregó max-width: 600px a .half-hero.

## Risks

- Bug en el codigo, VS se queja de algo en el post.html.

## Checklist

-Antes de editar la clase .half-hero
<img width="420" alt="Captura de pantalla 2023-07-25 a la(s) 9 40 48 p  m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674342/f7221208-5013-4eca-aa87-8ff72feb17f1">

-Luego de agregar media query a la clase .half-hero
https://github.com/jjmonsalveg/front-end-path/assets/126674342/04374f02-6967-4ba2-9304-7bbcb7373e50

## Also see

[How to Hide Elements in a Responsive Layout](https://www.w3docs.com/snippets/css/how-to-hide-elements-in-a-responsive-layout.html)
