### PR TITLE
Hacer ejercicio 13.2.1

### DIFF
--- a/sample_jekyll/css/main.css
+++ b/sample_jekyll/css/main.css
@@ -642,10 +642,13 @@ h2 ~ p {
     flex: 1;
   }
   /* BLOG STYLES */
-  .blog-recent {
+  /* .blog-recent {
     display: none;
-  }
+  } */
   .blog-previews {
     padding: 0;
+  }
+  .blog-cols {
+    flex-direction: column-reverse;
   }
 }


### PR DESCRIPTION
# ccs(Ejercicio 13.2.1)

En lugar de ocultar las publicaciones recientes en la página de índice del blog, se uso CSS para que se muestren en la parte superior de las páginas sobre las vistas previas de las publicaciones.

## Changelog

- Se agrego la propiedad flex-direction: column-reverse a la clase .blog-cols

No se si esta bien pero se visualiza lo que pide, lo que hice fue darme cuenta en el post.html que Recent Posts estaba a lo ultimo y elimine (comente) la propiedad display: none y utilice flex.


## Preview (Optional)

<img width="690" alt="Captura de pantalla 2023-08-09 a la(s) 12 42 35 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/7fec46e6-59c2-4b8e-bee1-4c0bc86cc74e">


