### PR TITLE
Añada ejercicio 13.2.1

### DIFF
--- a/sample_jekyll/css/main.css
+++ b/sample_jekyll/css/main.css
@@ -647,10 +647,15 @@ h2 ~ p {
     flex: 1;
   }
   /* BLOG STYLES */
-  .blog-recent {
+  /* .blog-recent {
     display: none;
-  }
+  } */
   .blog-previews {
     padding: 0;
+  }
+  .blog-cols {
+    align-items:flex-start;
+    flex-direction: column-reverse;
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
# CSS (ejercicio 13.2.1)

Se realizo el ejercicio 13.1.1 de CSS, donde se pedia:
-Mostrar las publicaciones recientes en la parte superior de las páginas sobre las vistas previas de las publicaciones, ubicadas en la página de índice del blog.

## Changelog

- Se agregó align-items:flex-start; flex-direction: column-reverse; justify-content: flex-start a .blog-cols.
- Se comentó display: none en .blog-recent para ver los cambios.

## Preview 

- Antes de editar la clase .blog-cols
<img width="708" alt="Captura de pantalla 2023-08-11 a la(s) 12 15 43 a  m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674342/b3358974-fe2d-4c9b-abcf-d58e96554eab">

- Luego de editar la clase .blog-cols
<img width="615" alt="Captura de pantalla 2023-08-11 a la(s) 12 15 53 a  m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674342/67bcb38b-21ce-4dba-b2bf-d83efd680966">

## Also see

- [Guide to Flexbox](https://www.joshwcomeau.com/css/interactive-guide-to-flexbox/#alignment-3)