### PR TITLE
Hacer ejercicio15.3.4

### DIFF
--- a/sample_jekyll/grid.html
+++ b/sample_jekyll/grid.html
@@ -6,6 +6,7 @@
         <style>
             .grid {
                 display: grid;
+                justify-items: start;
                 grid-template-columns: repeat(auto-fit, minmax(275px, 1fr));
                 grid-auto-rows: minmax(10em, 1fr);
                 grid-gap: 1em;
@@ -18,11 +19,19 @@
             .grid-feature {
                 grid-column: span 2;
             }
+
+            .grid-example {
+                align-self: center;
+                justify-self: end;
+                grid-column: span 2;
+                grid-row: span 2;
+            }
+
         </style>
     </head>
     <body>
         <div class="grid">
-            <div>
+            <div class="grid-example">
                 <h2>Big news today</h2>
                 Quick sync win-win-win or workflow ecosystem.
             </div>


### PR DESCRIPTION
# homework(html-css)

Se realizo el ejercicio 15.3.4 

## Changelog

- Se probaron diferentes estios de align-items y justify-items. Mas abajo se observan algunos pantallazos
- Se añadió únicamente al primer elemento de la cuadricula el estilo align-self: center y justify-self: end;
- Se añadió al mismo elemento grid-column: span 2; y grid-row: span 2;

## Preview

- a) justify-end
<img width="1439" alt="justifyend" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/3c335465-760a-404b-a2bd-16654821e1a2">

b) justify-start
<img width="1440" alt="justifystart" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/2c08e434-cbb1-4ec2-9d0e-d51cf4f78051">

c) align-start
<img width="1440" alt="alignStart" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/577d5aa0-9c1d-4502-a08e-78bc0aee29e5">

d) align-end
<img width="1440" alt="alignEnd" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/23324662-5e71-4081-aed7-e44485d1b012">

- Se observa que unicamente se modifica la posición del elemento seleccionado (Big news today)
<img width="1430" alt="Captura de pantalla 2023-10-16 a la(s) 8 38 50 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/ae1d648f-b1e2-4945-bcd4-92f2c263ec4c">

- Se observa que a al agregar grid-column: span 2; y grid-row: span 2; el elemento ocupa dos celdas de espacios tanto en horizontal como en vertical
<img width="1439" alt="Captura de pantalla 2023-10-16 a la(s) 8 42 08 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/f69a8c34-555c-45b8-8960-fa809af8a7fd">

## Also see

<img width="664" alt="Captura de pantalla 2023-10-16 a la(s) 9 05 21 p m" src="https://github.com/jjmonsalveg/front-end-path/assets/126674411/b70f62f4-19c9-43c1-aa9b-cc984f69aa3c">

NO SE DEBERIA MEZCLAR